### PR TITLE
Specific Instructions with generic input/output to operations

### DIFF
--- a/src/RetroEmu.Devices/DMG/CPU/Instructions/IInstruction.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Instructions/IInstruction.cs
@@ -5,4 +5,5 @@ internal interface IInstruction
 	public WriteType WriteOp { get; }
 	public OpType Op { get; }
 	public FetchType FetchOp { get; }
+	unsafe int Execute(Processor processor, delegate*<Processor, (byte, ushort)>[] fetchOps, delegate*<Processor, IOperationInput, IOperationOutput>[] ops, delegate*<Processor, ushort, byte>[] writeOps);
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Instructions/Instruction.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Instructions/Instruction.cs
@@ -1,3 +1,14 @@
 namespace RetroEmu.Devices.DMG.CPU.Instructions;
 
-internal record Instruction(WriteType WriteOp, OpType Op, FetchType FetchOp) : IInstruction;
+internal record Instruction(WriteType WriteOp, OpType Op, FetchType FetchOp) : IInstruction
+{
+    public unsafe int Execute(Processor processor, delegate*<Processor, (byte, ushort)>[] fetchOps,
+        delegate*<Processor, IOperationInput, IOperationOutput>[] ops, delegate*<Processor, ushort, byte>[] writeOps)
+    {
+			var (fetchCycles, fetchResult) = fetchOps[(int)FetchOp](processor);
+            var operationOutput = ops[(int)Op](processor, new OperationInput(fetchResult));
+            var writeCycles = writeOps[(int)WriteOp](processor, operationOutput.Value);
+
+            return fetchCycles + operationOutput.Cycles + writeCycles;
+    }
+}

--- a/src/RetroEmu.Devices/DMG/CPU/Instructions/JumpInstruction.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Instructions/JumpInstruction.cs
@@ -1,0 +1,19 @@
+using System;
+using RetroEmu.Devices.DMG.CPU.Instructions;
+
+namespace RetroEmu.Devices.DMG.CPU;
+
+internal record JumpInstruction(WriteType WriteOp, OpType Op, FetchType FetchOp, Func<Processor, bool> Condition) : IInstruction
+{
+    public unsafe int Execute(Processor processor, delegate*<Processor, (byte, ushort)>[] fetchOps,
+        delegate*<Processor, IOperationInput, IOperationOutput>[] ops, delegate*<Processor, ushort, byte>[] writeOps)
+    {
+        var condition = Condition(processor);
+        
+        var (fetchCycles, fetchResult) = fetchOps[(int)FetchOp](processor);
+        var operationOutput = ops[(int)Op](processor, new JumpOperationInput(fetchResult, condition));
+        var writeCycles = writeOps[(int)WriteOp](processor, operationOutput.Value);
+
+        return fetchCycles + operationOutput.Cycles + writeCycles;
+    }
+}

--- a/src/RetroEmu.Devices/DMG/CPU/Instructions/OpType.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Instructions/OpType.cs
@@ -9,11 +9,8 @@ internal enum OpType : byte
 	And,
 	Dec,
 	Ld,
-	JpNZ,
 	Jp,
-	JpZ,
-	JpNC,
-	JpC,
+	JpConditionally,
 	Sbc,
 	Sub
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Adc.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Adc.cs
@@ -22,43 +22,44 @@ namespace RetroEmu.Devices.DMG.CPU
             _instructions[Opcode.Adc_A_N8] = new Instruction(WriteType.A, OpType.Adc, FetchType.N8);
         }
 	    
-		private static (byte, ushort) Adc(Processor processor, ushort value)
+	    private static OperationOutput Adc(Processor processor, IOperationInput operationInput) => processor.Adc(operationInput);
+		private OperationOutput Adc(IOperationInput operationInput)
 		{
-			var carry = processor.IsSet(Flag.Carry) ? 1 : 0;
-			var registerA = *processor.Registers.A;
-            var result = (int)registerA + (int)value + (int)carry;
+			var carry = IsSet(Flag.Carry) ? 1 : 0;
+			var registerA = *Registers.A;
+            var result = (int)registerA + (int)operationInput.Value + (int)carry;
 
 			if (result > 0xFF)
 			{
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
 			}
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
 			if (result > 0x0F)
 			{
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
 			}
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
-            processor.ClearFlag(Flag.Subtract);
+            ClearFlag(Flag.Subtract);
 
 			if (result == 0)
 			{
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
 			}
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            *processor.Registers.A = (byte)result;
-			return (4, (ushort)result); // cycles
+            *Registers.A = (byte)result;
+            return new OperationOutput((ushort)result, 4);
 		}
 
     }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Add.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Add.cs
@@ -30,107 +30,111 @@ namespace RetroEmu.Devices.DMG.CPU
 			_instructions[Opcode.Add_SP_N8] = new Instruction(WriteType.SP, OpType.AddSP, FetchType.N8);
         }
 
-		private static (byte, ushort) Add(Processor processor, ushort value)
+	    private static OperationOutput Add(Processor processor, IOperationInput operationInput) => processor.Add(operationInput);
+        private static OperationOutput Add16(Processor processor, IOperationInput operationInput) => processor.Add16(operationInput);
+	    private static OperationOutput AddSP(Processor processor, IOperationInput operationInput) => processor.AddSP(operationInput);
+        
+		private OperationOutput Add(IOperationInput operationInput)
 		{
-			var registerA = *processor.Registers.A;
-			var result = (int)registerA + (int)value;
+			var registerA = *Registers.A;
+			var result = (int)registerA + (int)operationInput.Value;
 
 			if (result > 0xFF)
 			{
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
             if (result > 0x0F)
 			{
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
-            processor.ClearFlag(Flag.Subtract);
+            ClearFlag(Flag.Subtract);
 
 			if (result == 0)
 			{
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
 			}
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-			return (4, (ushort)result); // cycles
-		}
+            return new OperationOutput((ushort)result, 4);
+        }
 
-        private static (byte, ushort) Add16(Processor processor, ushort value)
+        private OperationOutput Add16(IOperationInput operationInput)
         {
-            var registerHL = *processor.Registers.HL;
-            var result = (int)registerHL + (int)value;
+            var registerHL = *Registers.HL;
+            var result = (int)registerHL + (int)operationInput.Value;
 
             if (result > 0xFFFF)
             {
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
             if (result > 0x0FFF)
             {
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
-            processor.ClearFlag(Flag.Subtract);
+            ClearFlag(Flag.Subtract);
 
             if (result == 0)
             {
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
             }
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            return (8, (ushort)result); // cycles
+            return new OperationOutput((ushort)result, 8);
         }
 
-        private static (byte, ushort) AddSP(Processor processor, ushort value)
+        private OperationOutput AddSP(IOperationInput operationInput)
         {
-            var registerSP = *processor.Registers.SP;
-            var result = (int)registerSP + (int)value;
+            var registerSP = *Registers.SP;
+            var result = (int)registerSP + (int)operationInput.Value;
 
             if (result > 0xFFFF) // Set or reset according to operation?
             {
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
             if (result > 0x0FFF) // Set or reset according to operation?
             {
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
-            processor.ClearFlag(Flag.Subtract);
-            processor.ClearFlag(Flag.Zero);
+            ClearFlag(Flag.Subtract);
+            ClearFlag(Flag.Zero);
 
-            return (12, (ushort)result); // cycles (Not sure why this one is more expensive)
+            return new OperationOutput((ushort)result, 12); // cycles (Not sure why this one is more expensive)
         }
     }
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.And.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.And.cs
@@ -20,25 +20,26 @@ namespace RetroEmu.Devices.DMG.CPU
 			_instructions[Opcode.And_A_N8] = new Instruction(WriteType.A, OpType.And, FetchType.N8);
         }
 
-		private static (byte, ushort) And(Processor processor, ushort value)
+		private static OperationOutput And(Processor processor, IOperationInput operationInput) => processor.And(operationInput);
+		private OperationOutput And(IOperationInput operationInput)
         {
-            var registerA = *processor.Registers.A;
+            var registerA = *Registers.A;
 			var result = (int)registerA & (int)registerA;
 
             if (result == 0)
             {
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
             }
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            processor.ClearFlag(Flag.Subtract);
-            processor.SetFlag(Flag.HalfCarry);
-            processor.ClearFlag(Flag.Carry);
+            ClearFlag(Flag.Subtract);
+            SetFlag(Flag.HalfCarry);
+            ClearFlag(Flag.Carry);
 
-			return (4, (ushort)result); // cycles
+			return new OperationOutput((ushort)result, 4);
 		}
     }
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Dec.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Dec.cs
@@ -19,40 +19,42 @@ namespace RetroEmu.Devices.DMG.CPU
             _instructions[Opcode.Dec_XHL] = new Instruction(WriteType.XHL, OpType.Dec, FetchType.XHL);
         }
 
-        private static (byte, ushort) Dec(Processor processor, ushort value)
+        private static OperationOutput Dec(Processor processor, IOperationInput operationInput) => processor.Dec(operationInput);
+        
+        private OperationOutput Dec(IOperationInput operationInput)
         {
-            var result = (int)value - 1;
+            var result = (int)operationInput.Value - 1;
 
             if (result > 0xFF)
             {
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
             if (result == 0x0F)
             {
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
-            processor.SetFlag(Flag.Subtract);
+            SetFlag(Flag.Subtract);
 
             if (result == 0)
             {
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
             }
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            return (4, (ushort)result); // cycles
+            return new OperationOutput((ushort)result, 4);
         }
     }
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Flags.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Flags.cs
@@ -12,7 +12,7 @@ namespace RetroEmu.Devices.DMG.CPU
             *Registers.F ^= (byte)flag;
         }
 
-        private void SetFlag(Flag flag)
+        internal void SetFlag(Flag flag)
         {
             *Registers.F |= (byte)flag;
         }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Ld.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Ld.cs
@@ -45,9 +45,10 @@ namespace RetroEmu.Devices.DMG.CPU
             _instructions[Opcode.Ld_XC_A] = new Instruction(WriteType.XC, OpType.Ld, FetchType.A);
         }
 
-        private static (byte, ushort) Load(Processor processor, ushort value)
+        private static OperationOutput Load(Processor processor, IOperationInput operationInput) => Load(operationInput);
+        private static OperationOutput Load(IOperationInput operationInput)
         {
-            return (4, value);
+            return new OperationOutput(operationInput.Value, 4);
         }
 
     }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Sbc.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Sbc.cs
@@ -20,42 +20,43 @@ namespace RetroEmu.Devices.DMG.CPU
 			_instructions[Opcode.Sbc_A_N8] = new Instruction(WriteType.A, OpType.Sbc, FetchType.N8);
         }
 
-		private static (byte, ushort) Sbc(Processor processor, ushort value)
+		private static OperationOutput Sbc(Processor processor, IOperationInput operationInput) => processor.Sbc(operationInput);
+		private OperationOutput Sbc(IOperationInput operationInput)
         {
-            var carry = processor.IsSet(Flag.Carry) ? 1 : 0;
-            var registerA = *processor.Registers.A;
+            var carry = IsSet(Flag.Carry) ? 1 : 0;
+            var registerA = *Registers.A;
 			var result = (int)registerA - (int)registerA - (int)carry;
 
             if (result == 0)
             {
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
             }
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            processor.SetFlag(Flag.Subtract);
+            SetFlag(Flag.Subtract);
 
-            if ((registerA & 0x0F) - (value & 0x0F) < 0) // TODO: Doublecheck if this is correct
+            if ((registerA & 0x0F) - (operationInput.Value & 0x0F) < 0) // TODO: Doublecheck if this is correct
             {
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
             if (result < 0)
 			{
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
-			return (4, (ushort)result); // cycles
+			return new OperationOutput((ushort)result, 4);
 		}
     }
 }

--- a/src/RetroEmu.Devices/DMG/CPU/Processor.Sub.cs
+++ b/src/RetroEmu.Devices/DMG/CPU/Processor.Sub.cs
@@ -20,41 +20,42 @@ namespace RetroEmu.Devices.DMG.CPU
 			_instructions[Opcode.Sub_A_N8] = new Instruction(WriteType.A, OpType.Sub, FetchType.N8);
         }
 
-		private static (byte, ushort) Sub(Processor processor, ushort value)
+		private static OperationOutput Sub(Processor processor, IOperationInput operationInput) => processor.Sub(operationInput);
+		private OperationOutput Sub(IOperationInput operationInput)
 		{
-			var registerA = *processor.Registers.A;
+			var registerA = *Registers.A;
 			var result = (int)registerA - (int)registerA;
 
             if (result == 0)
             {
-                processor.SetFlag(Flag.Zero);
+                SetFlag(Flag.Zero);
             }
             else
             {
-                processor.ClearFlag(Flag.Zero);
+                ClearFlag(Flag.Zero);
             }
 
-            processor.SetFlag(Flag.Subtract);
+            SetFlag(Flag.Subtract);
 
-            if ((registerA & 0x0F) - (value & 0x0F) < 0) // TODO: Doublecheck if this is correct
+            if ((registerA & 0x0F) - (operationInput.Value & 0x0F) < 0) // TODO: Doublecheck if this is correct
             {
-                processor.SetFlag(Flag.HalfCarry);
+                SetFlag(Flag.HalfCarry);
             }
             else
             {
-                processor.ClearFlag(Flag.HalfCarry);
+                ClearFlag(Flag.HalfCarry);
             }
 
             if (result < 0)
 			{
-                processor.SetFlag(Flag.Carry);
+                SetFlag(Flag.Carry);
             }
             else
             {
-                processor.ClearFlag(Flag.Carry);
+                ClearFlag(Flag.Carry);
             }
 
-			return (4, (ushort)result); // cycles
+			return new OperationOutput((ushort)result, 4);
 		}
     }
 }


### PR DESCRIPTION
Pros:
- Allows operations be executed within the context of the processor
- Avoiding passing a Processor everywhere within the Processor
- More flexibility when defining input/output for operations
- More defined what output of operations are as IOperationOutput has properties "Value" and "Cycles"
- Allows for creating specific instructions for things like JumpInstruction which adds a condition

Cons:
- Additional wrapping of input output which:
  - potentially adds a performance penalty due to two more "new"s for each operation
  - casting when creating new instruction implementations
  - More setup-code